### PR TITLE
Set up basic auto-documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,3 +21,8 @@ jobs:
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
 
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-docs
+        path: docs/build/html/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,3 +26,10 @@ jobs:
       with:
         name: html-docs
         path: docs/build/html/
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: "Sphinx: Render docs"
+
+on: 
+  push:
+    branches:
+      - main
+      - 'docs/**'
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Build HTML
+      uses: ammaraskar/sphinx-action@master
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,18 @@
+API Reference
+=============
+
+Package
+-------
+
+.. automodule:: abm_project
+   :members:
+   :imported-members:
+   :undoc-members:
+
+Test module
+-----------
+
+.. automodule:: abm_project.test_module
+   :members:
+   :undoc-members:
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,32 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# running the project code. https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+project = "ABM Project"
+copyright = "2025, Karolina Chlopicka, Victoria Peterson, Shania Sinha, Henry Zwart"
+author = "Karolina Chlopicka, Victoria Peterson, Shania Sinha, Henry Zwart"
+release = "0.0.1"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinx.ext.viewcode"]
+
+templates_path = ["_templates"]
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,83 @@
+Contributing
+=============
+
+You want to contribute to this project? Awesome! There are just a couple of 
+housekeeping things to sort out before you dive in.
+
+uv
+^^^
+
+`uv <https://docs.astral.sh/uv/>`_ is a Python environment and package management tool.
+We use it in this repository to keep everything consistent and reproducible. If you don't
+already have uv installed, now is the time to do so :^)
+
+Once this is installed, configure the Python environment and download all required 
+dependencies by navigating to this repository and running:
+
+.. code-block:: console
+
+   $ uv sync
+
+This creates a virtual environment under ``.venv``, which is used implicitly whenever
+you run a uv command. *You do not need to manually activate this virtual
+environment*.
+
+Python packages can be added or removed from the project using ``uv add <PACKAGE_NAME>``
+and ``uv remove <PACKAGE_NAME>``. Doing so will update both:
+
+#. The pyproject.toml file, which maintains a human-readable project configuration, and
+#. The uv.lock file, which is a machine-generated file used to specify the project dependency
+   graph. 
+
+Note that the uv.lock file is not intended to be modified manually (or even really looked at). 
+For the most part, you can forget it exists.
+
+pre-commit and ruff
+^^^^^^^^^^^^^^^^^^^^
+
+We also use `pre-commit <https://pre-commit.com/>`_ with a 
+`ruff <https://docs.astral.sh/ruff/>`_ hook to automatically format all Python
+code prior to git commits.
+
+The specific ruff rules which will be applied are specified in the repository 
+pyproject.toml file. For more information, and a description of these rules, see
+the `ruff documentation <https://docs.astral.sh/ruff/rules/>`_.
+
+Installing pre-commit is straightforward using ``uv tool``:
+
+.. code-block:: console
+
+   $ uv tool install pre-commit --with pre-commit-uv --force-reinstall
+
+   # Check installation was successful
+   $ pre-commit --version  # Should say 'pre-commit 4.2.0' or similar
+
+Next you need to initialise pre-commit for this specific repository. This
+step will install the pre-commit hooks which will be run prior to every git
+commit:
+
+.. code-block:: console
+
+   # Initialise the pre-commit hooks
+   $ pre-commit install
+
+   # Check that everything works as intended (this should succeed)
+   $ pre-commit run --all-files
+
+If the above steps worked as expected, pre-commit should now automatically 
+lint and format any Python code prior to git commits, preventing accidentally
+checking in problematic code.
+
+Contribution process
+^^^^^^^^^^^^^^^^^^^^^
+
+1. Fork the repository.
+2. Create a new branch for your feature or bugfix.
+3. Make your changes and commit them with clear and concise messages.
+4. Ensure all tests pass, with `uv run pytest`
+5. Push your changes to your forked repository.
+6. Create a pull request to the main repository.
+7. If all GitHub CI checks are successful, great! It's time to request a review 
+   from one of the project maintainers.
+
+

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,0 +1,29 @@
+Getting started
+===============
+
+Setting up
+----------
+
+First things first, clone the project repository from GitHub:
+
+.. code-block:: console
+
+   $ gh repo clone VictorianHues/AgentBasedModeling
+
+This project uses `uv <https://docs.astral.sh/uv/>`_ for Python environment management.
+To ensure consistent results, we recommend using uv when working with this project or 
+re-running experiments. The following steps assume that you are using uv.
+
+To reproduce our results, first confgure the Python environment and install all 
+required dependencies:
+
+.. code-block:: console
+
+   $ uv sync
+
+And then run the simulation code:
+
+.. code-block:: console
+
+   $ uv run scripts/my_script.py
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,31 @@
+.. ABM Project documentation master file, created by
+   sphinx-quickstart on Tue Jun 10 12:37:11 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+ABM Project documentation
+=========================
+
+.. note::
+
+   This project is under active development.
+
+This project uses agent-based modelling to investigate the feedback cycle between 
+public support for climate action and individually-perceived climate change severity.
+
+Check out the :doc:`getting_started` section for details on how to contribute to this
+project, or reproduce our experiments.
+
+The repository is licensed under the `MIT License <https://github.com/VictorianHues/AgentBasedModeling/blob/main/LICENSE>`_. 
+
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   getting_started
+   api
+   contributing
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,5 @@ convention = "google"
 [tool.ruff.lint.per-file-ignores]
 # Ignore incorrect docstrings in the CLI
 "tests/*" = ["D"]
+"docs/*" = ["D"]
 

--- a/src/abm_project/__init__.py
+++ b/src/abm_project/__init__.py
@@ -1,0 +1,15 @@
+"""Agent-based modelling group project (test)."""
+
+from . import test_module as test_module
+
+
+def times_two(a: int) -> int:
+    """Multiply a number by two.
+
+    Args:
+        a: An integer
+
+    Returns:
+        2a
+    """
+    return 2 * a

--- a/src/abm_project/test_module.py
+++ b/src/abm_project/test_module.py
@@ -1,0 +1,14 @@
+"""A test module."""
+
+
+def one_plus_one(a: int, b: int) -> int:
+    """Adds two numbers.
+
+    Args:
+        a: An integer
+        b: Another integer
+
+    Returns:
+        The sum of a and b.
+    """
+    return a + b


### PR DESCRIPTION
This PR adds basic auto-documentation with [sphinx](https://www.sphinx-doc.org/en/master/index.html).

Documentation is located under the `docs/` directory. So far it only includes the "getting started" and "contributing" content from the README, and a couple of example functions to illustrate usage.

To test out the documentation, first pull this branch, then:

```
# Install Sphinx, the tool used to generate the docs
uv tool install sphinx

# Build the docs
cd docs && make html

# Open the build documentation
open build/html/index.html
```

I've also added a GitHub workflow to build and deploy the documentation whenever new changes are pushed to the `main` branch.

**Still to-do:** Set up a GitHub page to ingest the built documentation. I need @VictorianHues help with this, as I don't have the required access.

## How to add documentation

Sphinx can automatically generate documentation from Python docstrings. So whenever you write a function/class/module, if you add a docstring, then Sphinx can read it. 

If the new code is part of an existing, already-included module (file), then Sphinx will automatically add it to the documentation. If you are adding a new module, then you need to add it to `docs/source/api.rst` in order for it to show up.

## Ruff docstring reminders

I've included a ruff rule to check that all functions, classes, and modules are properly documented. In particular, it will not let you commit code that is missing docstrings. This can be a bit of a pain to start out with, so let me know if you think it needs to be relaxed. However, in practice I find it helpful, as it ensures that the docs are always up-to-date and building successfully.  

If you are using VSCode, the [autoDocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) extension makes this process much less painful. 

> [!NOTE]
> Currently [Google docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) are the default format, and ruff will check for these. If you prefer Numpy docstrings this is easily changed.